### PR TITLE
Fix module installation issues by enforcing dependencies.

### DIFF
--- a/config/install/core.entity_form_display.storage_assignment.storage_assignment.default.yml
+++ b/config/install/core.entity_form_display.storage_assignment.storage_assignment.default.yml
@@ -2,6 +2,9 @@ uuid: 9416407f-5497-415a-905f-0dc6c2fa7275
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.field.storage_assignment.storage_assignment.field_storage_assignment_status

--- a/config/install/core.entity_form_display.storage_unit.storage_unit.default.yml
+++ b/config/install/core.entity_form_display.storage_unit.storage_unit.default.yml
@@ -2,6 +2,9 @@ uuid: 0db59610-81db-4756-b817-eb1b8d513176
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.field.storage_unit.storage_unit.field_storage_area

--- a/config/install/core.entity_view_display.storage_assignment.storage_assignment.default.yml
+++ b/config/install/core.entity_view_display.storage_assignment.storage_assignment.default.yml
@@ -2,6 +2,9 @@ uuid: 388b3681-1258-4361-8fb1-69c10257603f
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.field.storage_assignment.storage_assignment.field_storage_assignment_status

--- a/config/install/core.entity_view_display.storage_unit.storage_unit.default.yml
+++ b/config/install/core.entity_view_display.storage_unit.storage_unit.default.yml
@@ -2,6 +2,9 @@ uuid: 5cb82e1b-221a-42d5-a81e-3652c99404da
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.field.storage_unit.storage_unit.field_storage_area

--- a/config/install/eck.eck_entity_type.storage_assignment.yml
+++ b/config/install/eck.eck_entity_type.storage_assignment.yml
@@ -1,7 +1,12 @@
 uuid: 941e31e1-d36f-4919-8145-1719d15187e8
 langcode: en
 status: false
-dependencies: {  }
+dependencies:
+  module:
+    - eck
+  enforced:
+    module:
+      - storage_manager
 id: storage_assignment
 label: storage_assignment
 uid: true

--- a/config/install/eck.eck_entity_type.storage_unit.yml
+++ b/config/install/eck.eck_entity_type.storage_unit.yml
@@ -1,7 +1,12 @@
 uuid: 45c90ed6-9752-4c7d-b102-98353a52b078
 langcode: en
 status: false
-dependencies: {  }
+dependencies:
+  module:
+    - eck
+  enforced:
+    module:
+      - storage_manager
 id: storage_unit
 label: storage_unit
 uid: false

--- a/config/install/eck.eck_type.storage_assignment.storage_assignment.yml
+++ b/config/install/eck.eck_type.storage_assignment.storage_assignment.yml
@@ -4,6 +4,9 @@ status: true
 dependencies:
   config:
     - eck.eck_entity_type.storage_assignment
+  enforced:
+    module:
+      - storage_manager
 name: storage_assignment
 type: storage_assignment
 description: ''

--- a/config/install/eck.eck_type.storage_unit.storage_unit.yml
+++ b/config/install/eck.eck_type.storage_unit.storage_unit.yml
@@ -4,6 +4,9 @@ status: true
 dependencies:
   config:
     - eck.eck_entity_type.storage_unit
+  enforced:
+    module:
+      - storage_manager
 name: storage_unit
 type: storage_unit
 description: ''

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_assignment_status.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_assignment_status.yml
@@ -2,6 +2,9 @@ uuid: 8468ed95-0fd8-4b83-bae3-24617a616e43
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_assignment_status

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_end_date.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_end_date.yml
@@ -2,6 +2,9 @@ uuid: 7f4c0872-9f30-4d65-bbfa-ca0e89931263
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_end_date

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_issue_note.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_issue_note.yml
@@ -2,6 +2,9 @@ uuid: acde04ee-8c10-4048-90e8-1d3f206a40b6
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_issue_note

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_issue_open.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_issue_open.yml
@@ -2,6 +2,9 @@ uuid: 780878d5-8d7e-4e2a-8b45-b87deed4f303
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_issue_open

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_price_snapshot.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_price_snapshot.yml
@@ -2,6 +2,9 @@ uuid: 3c153e4c-bc6d-45c0-accb-11d6cdb68cdd
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_price_snapshot

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_start_date.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_start_date.yml
@@ -2,6 +2,9 @@ uuid: 3a5c98b1-10d3-4e4e-b8df-062cded06bf2
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_start_date

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_stripe_sub_id.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_stripe_sub_id.yml
@@ -2,6 +2,9 @@ uuid: 0d04364f-f6f6-4a95-b11f-9bdde76329a5
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_stripe_sub_id

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_unit.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_unit.yml
@@ -2,6 +2,9 @@ uuid: e9ab4ffa-d3bf-450a-80f2-e0adcf79b240
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - eck.eck_type.storage_unit.storage_unit

--- a/config/install/field.field.storage_assignment.storage_assignment.field_storage_user.yml
+++ b/config/install/field.field.storage_assignment.storage_assignment.field_storage_user.yml
@@ -2,6 +2,9 @@ uuid: 3d6e26a1-7675-431b-8756-d4ae40e01f5a
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_assignment.storage_assignment
     - field.storage.storage_assignment.field_storage_user

--- a/config/install/field.field.storage_unit.storage_unit.field_storage_area.yml
+++ b/config/install/field.field.storage_unit.storage_unit.field_storage_area.yml
@@ -2,6 +2,9 @@ uuid: aa6acc57-8ed8-4d9e-ad28-360b510a3be6
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.storage.storage_unit.field_storage_area

--- a/config/install/field.field.storage_unit.storage_unit.field_storage_note.yml
+++ b/config/install/field.field.storage_unit.storage_unit.field_storage_note.yml
@@ -2,6 +2,9 @@ uuid: 9001fecb-2a2e-4984-9bb9-ef5bf02f5109
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.storage.storage_unit.field_storage_note

--- a/config/install/field.field.storage_unit.storage_unit.field_storage_status.yml
+++ b/config/install/field.field.storage_unit.storage_unit.field_storage_status.yml
@@ -2,6 +2,9 @@ uuid: 6773c1d6-f3c4-4be4-913f-2cf97e5d6fb1
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.storage.storage_unit.field_storage_status

--- a/config/install/field.field.storage_unit.storage_unit.field_storage_type.yml
+++ b/config/install/field.field.storage_unit.storage_unit.field_storage_type.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.storage.storage_unit.field_storage_type

--- a/config/install/field.field.storage_unit.storage_unit.field_storage_unit_id.yml
+++ b/config/install/field.field.storage_unit.storage_unit.field_storage_unit_id.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.storage.storage_unit.field_storage_unit_id

--- a/config/install/field.field.storage_unit.storage_unit.field_storage_x.yml
+++ b/config/install/field.field.storage_unit.storage_unit.field_storage_x.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.storage.storage_unit.field_storage_x

--- a/config/install/field.field.storage_unit.storage_unit.field_storage_y.yml
+++ b/config/install/field.field.storage_unit.storage_unit.field_storage_y.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - eck.eck_type.storage_unit.storage_unit
     - field.storage.storage_unit.field_storage_y

--- a/config/install/field.field.taxonomy_term.storage_type.field_monthly_price.yml
+++ b/config/install/field.field.taxonomy_term.storage_type.field_monthly_price.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   config:
     - field.storage.taxonomy_term.field_monthly_price
     - taxonomy.vocabulary.storage_type

--- a/config/install/field.storage.storage_assignment.field_storage_assignment_status.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_assignment_status.yml
@@ -2,6 +2,9 @@ uuid: 8933010d-a800-48c3-9e99-0c8d97b02cf9
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
     - options

--- a/config/install/field.storage.storage_assignment.field_storage_end_date.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_end_date.yml
@@ -2,6 +2,9 @@ uuid: d15dd9d3-b338-401d-9997-5eaaa7271417
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - datetime
     - eck

--- a/config/install/field.storage.storage_assignment.field_storage_issue_note.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_issue_note.yml
@@ -2,6 +2,9 @@ uuid: a37e55e0-6419-45ba-af71-3a117a658830
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_assignment.field_storage_issue_note

--- a/config/install/field.storage.storage_assignment.field_storage_issue_open.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_issue_open.yml
@@ -2,6 +2,9 @@ uuid: 14977322-14d6-40af-aef5-09f7fc4e99a8
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_assignment.field_storage_issue_open

--- a/config/install/field.storage.storage_assignment.field_storage_price_snapshot.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_price_snapshot.yml
@@ -2,6 +2,9 @@ uuid: 87d46a2e-8ccb-43ab-b062-b0d4581822ac
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_assignment.field_storage_price_snapshot

--- a/config/install/field.storage.storage_assignment.field_storage_start_date.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_start_date.yml
@@ -2,6 +2,9 @@ uuid: a24a9530-2d43-4158-bc17-da4556e24f27
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - datetime
     - eck

--- a/config/install/field.storage.storage_assignment.field_storage_stripe_sub_id.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_stripe_sub_id.yml
@@ -2,6 +2,9 @@ uuid: c51a1fd8-1ac4-4ec1-aef9-0a5c3c910396
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_assignment.field_storage_stripe_sub_id

--- a/config/install/field.storage.storage_assignment.field_storage_unit.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_unit.yml
@@ -2,6 +2,9 @@ uuid: 5231eb40-f390-4314-9782-4e2bf3f459af
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_assignment.field_storage_unit

--- a/config/install/field.storage.storage_assignment.field_storage_user.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_user.yml
@@ -2,6 +2,9 @@ uuid: 89a63781-a36c-4526-8eae-4fc377f5fc79
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
     - user

--- a/config/install/field.storage.storage_unit.field_storage_area.yml
+++ b/config/install/field.storage.storage_unit.field_storage_area.yml
@@ -2,6 +2,9 @@ uuid: e0478f41-2c86-4c97-9def-154c27d6eb50
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
     - taxonomy

--- a/config/install/field.storage.storage_unit.field_storage_note.yml
+++ b/config/install/field.storage.storage_unit.field_storage_note.yml
@@ -2,6 +2,9 @@ uuid: effce888-104a-40b4-8d05-be3a45d0c396
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_unit.field_storage_note

--- a/config/install/field.storage.storage_unit.field_storage_status.yml
+++ b/config/install/field.storage.storage_unit.field_storage_status.yml
@@ -2,6 +2,9 @@ uuid: 5d53a8f5-db23-4895-aeee-ab52c7c81b4f
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
     - options

--- a/config/install/field.storage.storage_unit.field_storage_type.yml
+++ b/config/install/field.storage.storage_unit.field_storage_type.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
     - taxonomy

--- a/config/install/field.storage.storage_unit.field_storage_unit_id.yml
+++ b/config/install/field.storage.storage_unit.field_storage_unit_id.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_unit.field_storage_unit_id

--- a/config/install/field.storage.storage_unit.field_storage_x.yml
+++ b/config/install/field.storage.storage_unit.field_storage_x.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_unit.field_storage_x

--- a/config/install/field.storage.storage_unit.field_storage_y.yml
+++ b/config/install/field.storage.storage_unit.field_storage_y.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - eck
 id: storage_unit.field_storage_y

--- a/config/install/field.storage.taxonomy_term.field_monthly_price.yml
+++ b/config/install/field.storage.taxonomy_term.field_monthly_price.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
 dependencies:
+  enforced:
+    module:
+      - storage_manager
   module:
     - taxonomy
 id: taxonomy_term.field_monthly_price

--- a/config/install/taxonomy.vocabulary.storage_area.yml
+++ b/config/install/taxonomy.vocabulary.storage_area.yml
@@ -1,7 +1,10 @@
 uuid: 2f50ffba-873d-45f8-acb5-d4b067fc9092
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - storage_manager
 name: storage_area
 vid: storage_area
 description: null

--- a/config/install/taxonomy.vocabulary.storage_type.yml
+++ b/config/install/taxonomy.vocabulary.storage_type.yml
@@ -1,7 +1,10 @@
 uuid: ab146d4c-8217-46bb-b16a-def5fcb9028f
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - storage_manager
 name: storage_type
 vid: storage_type
 description: null


### PR DESCRIPTION
The storage_manager module was failing to install its configuration correctly because the configuration files in `config/install` were missing an enforced dependency on the module itself. This resulted in missing vocabularies and fields, and a fatal error when trying to create a `storage_unit` entity.

This commit fixes the issue by adding `enforced: module: - storage_manager` to the `dependencies` section of all configuration files. This ensures that Drupal's configuration management system correctly associates the configuration with the module and installs it when the module is enabled.