### PR TITLE
Fix configuration dependency issues.

### DIFF
--- a/config/install/field.storage.storage_assignment.field_storage_assignment_status.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_assignment_status.yml
@@ -2,11 +2,12 @@ uuid: 8933010d-a800-48c3-9e99-0c8d97b02cf9
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
-    - eck
     - options
 id: storage_assignment.field_storage_assignment_status
 field_name: field_storage_assignment_status

--- a/config/install/field.storage.storage_assignment.field_storage_end_date.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_end_date.yml
@@ -2,12 +2,13 @@ uuid: d15dd9d3-b338-401d-9997-5eaaa7271417
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
     - datetime
-    - eck
 id: storage_assignment.field_storage_end_date
 field_name: field_storage_end_date
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_assignment.field_storage_issue_note.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_issue_note.yml
@@ -2,11 +2,13 @@ uuid: a37e55e0-6419-45ba-af71-3a117a658830
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_assignment.field_storage_issue_note
 field_name: field_storage_issue_note
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_assignment.field_storage_issue_open.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_issue_open.yml
@@ -2,11 +2,13 @@ uuid: 14977322-14d6-40af-aef5-09f7fc4e99a8
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_assignment.field_storage_issue_open
 field_name: field_storage_issue_open
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_assignment.field_storage_price_snapshot.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_price_snapshot.yml
@@ -2,11 +2,13 @@ uuid: 87d46a2e-8ccb-43ab-b062-b0d4581822ac
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_assignment.field_storage_price_snapshot
 field_name: field_storage_price_snapshot
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_assignment.field_storage_start_date.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_start_date.yml
@@ -2,12 +2,13 @@ uuid: a24a9530-2d43-4158-bc17-da4556e24f27
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
     - datetime
-    - eck
 id: storage_assignment.field_storage_start_date
 field_name: field_storage_start_date
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_assignment.field_storage_stripe_sub_id.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_stripe_sub_id.yml
@@ -2,11 +2,13 @@ uuid: c51a1fd8-1ac4-4ec1-aef9-0a5c3c910396
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_assignment.field_storage_stripe_sub_id
 field_name: field_storage_stripe_sub_id
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_assignment.field_storage_unit.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_unit.yml
@@ -2,11 +2,13 @@ uuid: 5231eb40-f390-4314-9782-4e2bf3f459af
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_assignment.field_storage_unit
 field_name: field_storage_unit
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_assignment.field_storage_user.yml
+++ b/config/install/field.storage.storage_assignment.field_storage_user.yml
@@ -2,12 +2,13 @@ uuid: 89a63781-a36c-4526-8eae-4fc377f5fc79
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_assignment
   enforced:
     module:
       - storage_manager
   module:
-    - eck
-    - user
+    - core
 id: storage_assignment.field_storage_user
 field_name: field_storage_user
 entity_type: storage_assignment

--- a/config/install/field.storage.storage_unit.field_storage_area.yml
+++ b/config/install/field.storage.storage_unit.field_storage_area.yml
@@ -2,12 +2,13 @@ uuid: e0478f41-2c86-4c97-9def-154c27d6eb50
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_unit
   enforced:
     module:
       - storage_manager
   module:
-    - eck
-    - taxonomy
+    - core
 id: storage_unit.field_storage_area
 field_name: field_storage_area
 entity_type: storage_unit

--- a/config/install/field.storage.storage_unit.field_storage_note.yml
+++ b/config/install/field.storage.storage_unit.field_storage_note.yml
@@ -2,11 +2,13 @@ uuid: effce888-104a-40b4-8d05-be3a45d0c396
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_unit
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_unit.field_storage_note
 field_name: field_storage_note
 entity_type: storage_unit

--- a/config/install/field.storage.storage_unit.field_storage_status.yml
+++ b/config/install/field.storage.storage_unit.field_storage_status.yml
@@ -2,11 +2,12 @@ uuid: 5d53a8f5-db23-4895-aeee-ab52c7c81b4f
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_unit
   enforced:
     module:
       - storage_manager
   module:
-    - eck
     - options
 id: storage_unit.field_storage_status
 field_name: field_storage_status

--- a/config/install/field.storage.storage_unit.field_storage_type.yml
+++ b/config/install/field.storage.storage_unit.field_storage_type.yml
@@ -1,12 +1,13 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_unit
   enforced:
     module:
       - storage_manager
   module:
-    - eck
-    - taxonomy
+    - core
 id: storage_unit.field_storage_type
 field_name: field_storage_type
 entity_type: storage_unit

--- a/config/install/field.storage.storage_unit.field_storage_unit_id.yml
+++ b/config/install/field.storage.storage_unit.field_storage_unit_id.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_unit
   enforced:
     module:
       - storage_manager

--- a/config/install/field.storage.storage_unit.field_storage_x.yml
+++ b/config/install/field.storage.storage_unit.field_storage_x.yml
@@ -1,11 +1,13 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_unit
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_unit.field_storage_x
 field_name: field_storage_x
 entity_type: storage_unit

--- a/config/install/field.storage.storage_unit.field_storage_y.yml
+++ b/config/install/field.storage.storage_unit.field_storage_y.yml
@@ -1,11 +1,13 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - eck.eck_entity_type.storage_unit
   enforced:
     module:
       - storage_manager
   module:
-    - eck
+    - core
 id: storage_unit.field_storage_y
 field_name: field_storage_y
 entity_type: storage_unit

--- a/config/install/field.storage.taxonomy_term.field_monthly_price.yml
+++ b/config/install/field.storage.taxonomy_term.field_monthly_price.yml
@@ -1,11 +1,13 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - taxonomy.vocabulary.storage_type
   enforced:
     module:
       - storage_manager
   module:
-    - taxonomy
+    - core
 id: taxonomy_term.field_monthly_price
 field_name: field_monthly_price
 entity_type: taxonomy_term


### PR DESCRIPTION
The module was failing to install because of incorrect dependencies in the configuration files. The `field.storage.*.yml` files were missing dependencies on the entity types they were being attached to. This caused Drupal's configuration installer to try to create the fields before the entity types existed, resulting in a fatal error.

This commit fixes the issue by adding the correct `config` dependencies to all the `field.storage.*.yml` files. This ensures that the entity types are created before the fields, and the module can be installed correctly.