### PR TITLE
Add .install file to manage schema version.

### DIFF
--- a/storage_manager.install
+++ b/storage_manager.install
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Install, update, and uninstall functions for the Storage Manager module.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Sets the initial schema version.
+ */
+function storage_manager_install() {
+  // Set the initial schema version.
+  \Drupal::service('keyvalue')->get('system.schema')->set('storage_manager', 10001);
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * An empty update hook to set the initial schema version.
+ */
+function storage_manager_update_10001() {
+  // This is an empty update hook to set the initial schema version.
+  // No database changes are needed.
+  return t('Storage Manager module schema updated to 10001.');
+}


### PR DESCRIPTION
The module was showing a 'Schema information for module storage_manager was missing' error because it did not have an `.install` file to manage its schema version with Drupal's update system.

This commit adds a `storage_manager.install` file with implementations of `hook_install()` and `hook_update_10001()` to set the initial schema version for the module. This will resolve the error message and ensure that the module's updates can be tracked correctly in the future.