### PR TITLE
Updates the eck dependency syntax to rule out parsing issues.

### DIFF
--- a/storage_manager.info.yml
+++ b/storage_manager.info.yml
@@ -4,7 +4,7 @@ description: Manages storage units, assignments, and (optional) Stripe subscript
 core_version_requirement: ^10 || ^11
 package: MakeHaven
 dependencies:
-  - eck:eck
+  - eck
   - drupal:taxonomy
   - drupal:user
   - drupal:views


### PR DESCRIPTION
This commit changes the dependency declaration for ECK from `eck:eck` to `eck` in `storage_manager.info.yml`.

The root cause of the `PluginNotFoundException` for the 'storage_assignment' entity type is almost certainly that the module's folder name is incorrect in the user's installation, preventing Drupal from loading the configuration files. This change is a final step to ensure the module's code is as robust as possible before the user performs the necessary manual re-installation.

**Manual steps required by user:**
1.  Uninstall the `storage_manager` module.
2.  Verify the module's folder is named exactly `storage_manager`.
3.  Reinstall the `storage_manager` module.